### PR TITLE
build: Bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # JBZoo / Toolbox-Dev
 
-[![CI](https://github.com/JBZoo/Toolbox-Dev/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Toolbox-Dev/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Toolbox-Dev/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Toolbox-Dev?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Toolbox-Dev/coverage.svg)](https://shepherd.dev/github/JBZoo/Toolbox-Dev)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Toolbox-Dev/level.svg)](https://shepherd.dev/github/JBZoo/Toolbox-Dev)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/toolbox-dev/badge)](https://www.codefactor.io/repository/github/jbzoo/toolbox-dev/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/toolbox-dev/version)](https://packagist.org/packages/jbzoo/toolbox-dev/)    [![Total Downloads](https://poser.pugx.org/jbzoo/toolbox-dev/downloads)](https://packagist.org/packages/jbzoo/toolbox-dev/stats)    [![Dependents](https://poser.pugx.org/jbzoo/toolbox-dev/dependents)](https://packagist.org/packages/jbzoo/toolbox-dev/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/toolbox-dev)](https://github.com/JBZoo/Toolbox-Dev/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Toolbox-Dev/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Toolbox-Dev/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Toolbox-Dev/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Toolbox-Dev?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Toolbox-Dev/coverage.svg)](https://shepherd.dev/github/JBZoo/Toolbox-Dev)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Toolbox-Dev/level.svg)](https://shepherd.dev/github/JBZoo/Toolbox-Dev)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/toolbox-dev/badge)](https://www.codefactor.io/repository/github/jbzoo/toolbox-dev/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/toolbox-dev/version)](https://packagist.org/packages/jbzoo/toolbox-dev/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/toolbox-dev/downloads)](https://packagist.org/packages/jbzoo/toolbox-dev/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/toolbox-dev/dependents)](https://packagist.org/packages/jbzoo/toolbox-dev/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/toolbox-dev)](https://github.com/JBZoo/Toolbox-Dev/blob/master/LICENSE)
+
 
 Developer toolbox library that provides standardized development dependencies and debugging utilities for JBZoo projects on GitHub.
 

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "php"                         : "^8.2",
 
         "jbzoo/phpunit"               : "^7.2",
-        "jbzoo/codestyle"             : "^7.1.6",
-        "jbzoo/markdown"              : "^7.0",
+        "jbzoo/codestyle"             : "^7.2",
+        "jbzoo/markdown"              : "^7.0.2",
 
         "jbzoo/jbdump"                : ">=1.5.6|^7.0",
         "symfony/var-dumper"          : ">=7.3.4",


### PR DESCRIPTION
- Update jbzoo/codestyle to ^7.2.
- Update jbzoo/markdown to ^7.0.2.
- Improve README badge formatting for better readability.