### PR TITLE
8.0.0 — PHP 8.3+ floor & lock-step major

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ permissions:
   contents: read
 
 on:
+  schedule:
+    - cron: '0 4 * * *'   # daily 04:00 UTC canary keepalive
   pull_request:
     branches:
       - "*"
   push:
     branches:
       - 'master'
+  workflow_dispatch: {}
 
 env:
   COLUMNS: 120
@@ -34,12 +37,12 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -65,11 +68,12 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
           path: build/
+          overwrite: true
 
 
   linters:
@@ -77,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -99,11 +103,12 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
+          overwrite: true
 
 
   report:
@@ -111,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -133,8 +138,9 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}
           path: build/
+          overwrite: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ This package includes JBZoo's standardized toolchain via the Makefile system:
 - Acts as a single dependency to pull in all necessary development tools
 
 ### PHP Version Requirements
-- PHP 8.2+ required
+- PHP 8.3+ required
 - Compatible with PHP 8.3 and 8.4 (tested in CI)
 
 ### Testing Framework
@@ -67,7 +67,7 @@ This package is typically included as a development dependency in other JBZoo pr
 ```json
 {
     "require-dev": {
-        "jbzoo/toolbox-dev": "^7.0"
+        "jbzoo/toolbox-dev": "^8.0"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dump($variable);  // Outputs to stderr with optimized formatting
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - Composer for dependency management
 
 ## Integration
@@ -79,7 +79,7 @@ This package is designed to be included as a development dependency in JBZoo pro
 ```json
 {
     "require-dev": {
-        "jbzoo/toolbox-dev": "^7.0"
+        "jbzoo/toolbox-dev": "^8.0"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"                         : "^8.2",
+        "php"                         : "^8.3",
 
-        "jbzoo/phpunit"               : "^7.2",
-        "jbzoo/codestyle"             : "^7.2",
-        "jbzoo/markdown"              : "^7.0.2",
+        "jbzoo/phpunit"               : "^8.0",
+        "jbzoo/codestyle"             : "^8.0",
+        "jbzoo/markdown"              : "^8.0",
 
         "jbzoo/jbdump"                : ">=1.5.6|^7.0",
         "symfony/var-dumper"          : ">=7.3.4",
@@ -54,7 +54,7 @@
 
     "extra"             : {
         "branch-alias" : {
-            "dev-master" : "7.x-dev"
+            "dev-master" : "8.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "jbzoo/codestyle"             : "^8.0",
         "jbzoo/markdown"              : "^8.0",
 
-        "jbzoo/jbdump"                : ">=1.5.6|^7.0",
         "symfony/var-dumper"          : ">=7.3.4",
 
         "php-coveralls/php-coveralls" : ">=2.8.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,25 +10,15 @@
     @copyright  Copyright (C) JBZoo.com, All rights reserved.
     @see        https://github.com/JBZoo/Toolbox-Dev
 -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="tests/autoload.php"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
+<phpunit bootstrap="tests/autoload.php"
          executionOrder="random"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         stopOnRisky="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
+         stopOnRisky="false">
+    <coverage>
         <report>
             <clover outputFile="build/coverage_xml/main.xml"/>
             <php outputFile="build/coverage_cov/main.cov"/>
@@ -45,4 +35,10 @@
     <logging>
         <junit outputFile="build/coverage_junit/main.xml"/>
     </logging>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
Coordinated ecosystem-wide **8.0** major (packaging-driven; no public API change).

- Minimum PHP raised to **8.3** (CI: 8.3 / 8.4 / 8.5).
- All inter-package `jbzoo/*` deps → `^8.0`.

### Removed
- Dropped `jbzoo/jbdump` (legacy on `nextgen-2.0`, 0 usages ecosystem-wide; its `(double)`-cast broke cli's 8.5 output). `dump()` remains available via `symfony/var-dumper`.
